### PR TITLE
Removed http-client header instance sharing

### DIFF
--- a/src/Exchange.WebServices.NETCore/Core/EwsHttpWebRequest.cs
+++ b/src/Exchange.WebServices.NETCore/Core/EwsHttpWebRequest.cs
@@ -37,6 +37,11 @@ internal class EwsHttpWebRequest
     /// </summary>
     private readonly HttpClient _httpClient;
 
+    /// <summary>
+    ///     Backing message for collecting http headers
+    /// </summary>
+    private readonly HttpRequestMessage _backingMessage = new();
+
 
     /// <summary>
     ///     Gets or sets the value of the Accept HTTP header.
@@ -57,7 +62,7 @@ internal class EwsHttpWebRequest
     ///     A <see cref="T:System.Net.WebHeaderCollection" /> that contains the name/value pairs that make up the headers
     ///     for the HTTP request.
     /// </returns>
-    public HttpRequestHeaders Headers => _httpClient.DefaultRequestHeaders;
+    public HttpRequestHeaders Headers => _backingMessage.Headers;
 
     /// <summary>
     ///     Gets or sets the method for the request.
@@ -144,6 +149,14 @@ internal class EwsHttpWebRequest
         {
             Content = new StringContent(Content),
         };
+
+        message.Headers.ConnectionClose = _httpClient.DefaultRequestHeaders.ConnectionClose;
+
+        // Copy http headers into our request message
+        foreach (var (key, value) in _backingMessage.Headers)
+        {
+            message.Headers.Add(key, value);
+        }
 
         if (!string.IsNullOrEmpty(ContentType))
         {

--- a/tests/Exchange.WebServices.NETCore.Tests/ExchangeProvider.cs
+++ b/tests/Exchange.WebServices.NETCore.Tests/ExchangeProvider.cs
@@ -1,4 +1,8 @@
+#define TRACING
+
 using System.Reflection;
+
+using Exchange.WebServices.NETCore.Tests.Utility;
 
 using JetBrains.Annotations;
 
@@ -6,6 +10,7 @@ using Microsoft.Exchange.WebServices.Data;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web.TokenCacheProviders;
 using Microsoft.Identity.Web.TokenCacheProviders.InMemory;
@@ -66,6 +71,12 @@ public class ExchangeProvider
             Url = new Uri(options.ServiceUrl),
             ImpersonatedUserId = new ImpersonatedUserId(ConnectingIdType.PrincipalName, options.ImpersonationUpn),
             ServerCertificateValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            SendClientLatencies = true,
+#if TRACING
+            TraceEnabled = true,
+            TraceFlags = TraceFlags.All,
+            TraceListener = new EwsTraceListener(),
+#endif
         };
     }
 

--- a/tests/Exchange.WebServices.NETCore.Tests/ExchangeProvider.cs
+++ b/tests/Exchange.WebServices.NETCore.Tests/ExchangeProvider.cs
@@ -1,4 +1,4 @@
-#define TRACING
+// #define TRACING
 
 using System.Reflection;
 

--- a/tests/Exchange.WebServices.NETCore.Tests/Items/ItemOperationTests.cs
+++ b/tests/Exchange.WebServices.NETCore.Tests/Items/ItemOperationTests.cs
@@ -30,4 +30,29 @@ public class ItemOperationTests : IClassFixture<ExchangeProvider>
         var items = await service.FindItems(WellKnownFolderName.Inbox, filter, view);
         Assert.NotEmpty(items);
     }
+
+    [Fact]
+    public async Task ItemSuccessionTest()
+    {
+        var service = _provider.CreateTestService();
+
+        _ = await Folder.Bind(service, WellKnownFolderName.Inbox);
+
+        // The search filter to get unread email.
+        var filter = new SearchFilter.SearchFilterCollection(
+            LogicalOperator.And,
+            new SearchFilter.IsEqualTo(EmailMessageSchema.IsRead, false)
+        );
+        var view = new ItemView(1);
+
+        var items = await service.FindItems(WellKnownFolderName.Inbox, filter, view);
+        Assert.NotEmpty(items);
+
+        foreach (var item in items)
+        {
+            var mailItem = await Item.Bind(service, item.Id, [ItemSchema.MimeContent,]);
+
+            Assert.NotNull(mailItem.MimeContent);
+        }
+    }
 }

--- a/tests/Exchange.WebServices.NETCore.Tests/Utility/EwsTraceListener.cs
+++ b/tests/Exchange.WebServices.NETCore.Tests/Utility/EwsTraceListener.cs
@@ -1,0 +1,11 @@
+using Microsoft.Exchange.WebServices.Data;
+
+namespace Exchange.WebServices.NETCore.Tests.Utility;
+
+internal class EwsTraceListener : ITraceListener
+{
+    public void Trace(string traceType, string traceMessage)
+    {
+        Console.WriteLine("{0} {1}", traceType, traceMessage);
+    }
+}


### PR DESCRIPTION
Corrected the assignment of header values in `EwsHttpWebRequest`. The legacy code simply forwarded the `HttpRequestHeaders Headers => _httpClient.DefaultRequestHeaders;` property to the outside world, but in an earlier update I made changes to reuse the HttpClient instance, instead of allocating one each time a request is made. 

This had the unforeseen side-effect of re-populating the same HTTP-headers over and over again as the Headers instance is no longer bound to the `EwsHttpWebRequest` instance but shared across the whole ExchangeService instance.

Resolves #12 