### PR TITLE
Add back support for NET8 LTS

### DIFF
--- a/src/Exchange.WebServices.NETCore.Autodiscover/Exchange.WebServices.NETCore.Autodiscover.csproj
+++ b/src/Exchange.WebServices.NETCore.Autodiscover/Exchange.WebServices.NETCore.Autodiscover.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net9.0; net8.0</TargetFrameworks>
 
 		<PackageTags>ews exchange office365 Microsoft Web API Email Client Library C#</PackageTags>
 		<PackageProjectUrl>https://github.com/ItsClemi/ews-managed-api</PackageProjectUrl>

--- a/src/Exchange.WebServices.NETCore/Exchange.WebServices.NETCore.csproj
+++ b/src/Exchange.WebServices.NETCore/Exchange.WebServices.NETCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net9.0; net8.0</TargetFrameworks>
 
 		<AssemblyName>Exchange.WebServices.NETCore</AssemblyName>
 		<PackageId>Exchange.WebServices.NETCore</PackageId>


### PR DESCRIPTION
Not everyone is on the newest bits, so this PR would add support for NET8 to the package allowing people not on NET9 to still use this package. Fixes this error:
![image](https://github.com/user-attachments/assets/196420b9-6026-4964-b6d7-3d65080bf88b)

P.S. I'm switching from the sherlock1982/ews-managed-api fork to yours. Nice to see someone is still working on this. We need this for backward compatibility for clients that cannot move to Microsoft Graph
