### PR TITLE
[Breaking] OperationCanceledExceptions are now emitted for requests

### DIFF
--- a/src/Exchange.WebServices.NETCore/Core/EwsHttpWebRequest.cs
+++ b/src/Exchange.WebServices.NETCore/Core/EwsHttpWebRequest.cs
@@ -113,11 +113,11 @@ internal class EwsHttpWebRequest
     ///     Returns a response from an Internet resource.
     /// </summary>
     /// <param name="headersOnly">Enables header only fetching</param>
-    /// <param name="token"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>
     ///     A <see cref="T:System.Net.HttpWebResponse" /> that contains the response from the Internet resource.
     /// </returns>
-    public async Task<IEwsHttpWebResponse> GetResponse(bool headersOnly, CancellationToken token)
+    public async Task<IEwsHttpWebResponse> GetResponse(bool headersOnly, CancellationToken cancellationToken)
     {
         using var message = CreateRequestMessage();
 
@@ -128,7 +128,12 @@ internal class EwsHttpWebRequest
         HttpResponseMessage? response;
         try
         {
-            response = await _httpClient.SendAsync(message, completionOption, token);
+            response = await _httpClient.SendAsync(message, completionOption, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Forward cancellation token
+            throw;
         }
         catch (Exception exception)
         {

--- a/src/Exchange.WebServices.NETCore/Core/EwsXmlReader.cs
+++ b/src/Exchange.WebServices.NETCore/Core/EwsXmlReader.cs
@@ -177,7 +177,7 @@ internal class EwsXmlReader
     {
         if (xmlNamespace == XmlNamespace.NotSpecified)
         {
-            InternalReadElement(string.Empty, localName, nodeType);
+            await InternalReadElementAsync(string.Empty, localName, nodeType).ConfigureAwait(false);
         }
         else
         {
@@ -236,7 +236,7 @@ internal class EwsXmlReader
         XmlNodeType nodeType
     )
     {
-        await ReadAsync(nodeType);
+        await ReadAsync(nodeType).ConfigureAwait(false);
 
         if (LocalName != localName || NamespacePrefix != namespacePrefix)
         {

--- a/src/Exchange.WebServices.NETCore/Core/ExchangeService.cs
+++ b/src/Exchange.WebServices.NETCore/Core/ExchangeService.cs
@@ -604,22 +604,24 @@ public sealed class ExchangeService : ExchangeServiceBase
     /// </summary>
     /// <param name="folderId">The folder id.</param>
     /// <param name="propertySet">The property set.</param>
-    /// <param name="token"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>Folder</returns>
-    internal async Task<Folder?> BindToFolder(FolderId folderId, PropertySet propertySet, CancellationToken token)
+    internal async Task<Folder?> BindToFolder(
+        FolderId folderId,
+        PropertySet propertySet,
+        CancellationToken cancellationToken
+    )
     {
         EwsUtilities.ValidateParam(folderId);
         EwsUtilities.ValidateParam(propertySet);
 
         var responses = await InternalBindToFolders(
-            new[]
-            {
-                folderId,
-            },
-            propertySet,
-            ServiceErrorHandling.ThrowOnError,
-            token
-        );
+                [folderId,],
+                propertySet,
+                ServiceErrorHandling.ThrowOnError,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
 
         return responses[0].Folder;
     }
@@ -630,16 +632,16 @@ public sealed class ExchangeService : ExchangeServiceBase
     /// <typeparam name="TFolder">The type of the folder.</typeparam>
     /// <param name="folderId">The folder id.</param>
     /// <param name="propertySet">The property set.</param>
-    /// <param name="token"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>Folder</returns>
     internal async Task<TFolder> BindToFolder<TFolder>(
         FolderId folderId,
         PropertySet propertySet,
-        CancellationToken token
+        CancellationToken cancellationToken
     )
         where TFolder : Folder
     {
-        var result = await BindToFolder(folderId, propertySet, token);
+        var result = await BindToFolder(folderId, propertySet, cancellationToken).ConfigureAwait(false);
 
         if (result is not TFolder folder)
         {
@@ -676,13 +678,13 @@ public sealed class ExchangeService : ExchangeServiceBase
     /// <param name="folderIds">The Ids of the folders to bind to.</param>
     /// <param name="propertySet">The set of properties to load.</param>
     /// <param name="errorHandling">Type of error handling to perform.</param>
-    /// <param name="token"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>A ServiceResponseCollection providing results for each of the specified folder Ids.</returns>
     private Task<ServiceResponseCollection<GetFolderResponse>> InternalBindToFolders(
         IEnumerable<FolderId> folderIds,
         PropertySet propertySet,
         ServiceErrorHandling errorHandling,
-        CancellationToken token
+        CancellationToken cancellationToken
     )
     {
         var request = new GetFolderRequest(this, errorHandling)
@@ -692,7 +694,7 @@ public sealed class ExchangeService : ExchangeServiceBase
 
         request.FolderIds.AddRange(folderIds);
 
-        return request.ExecuteAsync(token);
+        return request.ExecuteAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/Exchange.WebServices.NETCore/Core/Requests/MultiResponseServiceRequest.cs
+++ b/src/Exchange.WebServices.NETCore/Core/Requests/MultiResponseServiceRequest.cs
@@ -42,7 +42,7 @@ internal abstract class MultiResponseServiceRequest<TResponse> : SimpleServiceRe
     /// </summary>
     /// <param name="service">The service.</param>
     /// <param name="errorHandlingMode"> Indicates how errors should be handled.</param>
-    internal MultiResponseServiceRequest(ExchangeService service, ServiceErrorHandling errorHandlingMode)
+    protected MultiResponseServiceRequest(ExchangeService service, ServiceErrorHandling errorHandlingMode)
         : base(service)
     {
         ErrorHandlingMode = errorHandlingMode;
@@ -128,10 +128,10 @@ internal abstract class MultiResponseServiceRequest<TResponse> : SimpleServiceRe
     ///     Executes this request.
     /// </summary>
     /// <returns>Service response collection.</returns>
-    internal async Task<ServiceResponseCollection<TResponse>> ExecuteAsync(CancellationToken token)
+    internal async Task<ServiceResponseCollection<TResponse>> ExecuteAsync(CancellationToken cancellationToken)
     {
-        var serviceResponses =
-            await InternalExecuteAsync<ServiceResponseCollection<TResponse>>(token).ConfigureAwait(false);
+        var serviceResponses = await InternalExecuteAsync<ServiceResponseCollection<TResponse>>(cancellationToken)
+            .ConfigureAwait(false);
 
         if (ErrorHandlingMode == ServiceErrorHandling.ThrowOnError)
         {

--- a/tests/Exchange.WebServices.NETCore.Tests/Folders/FolderBindCancellationTests.cs
+++ b/tests/Exchange.WebServices.NETCore.Tests/Folders/FolderBindCancellationTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Exchange.WebServices.Data;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Exchange.WebServices.NETCore.Tests.Folders;
+
+public class FolderBindCancellationTests : IClassFixture<ExchangeProvider>
+{
+    private readonly ExchangeProvider _provider;
+
+    public FolderBindCancellationTests(ExchangeProvider provider)
+    {
+        _provider = provider;
+    }
+
+
+    [Fact]
+    public async Task BindFolder_Cancellation_ThrowsOperationCancelledException()
+    {
+        using var service = _provider.CreateTestService();
+
+        // Create a cancelled cancellation token
+        using var source = new CancellationTokenSource();
+        await source.CancelAsync();
+
+        try
+        {
+            _ = await Folder.Bind(service, WellKnownFolderName.Inbox, source.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Do nothing
+        }
+    }
+}


### PR DESCRIPTION
The current implementation of the `EwsHttpWebRequest` doesn't catch the OperationCancelledException, instead it wraps it into a `EwsHttpClientException`, due to the default exception handler.

https://github.com/ItsClemi/ews-managed-api/blob/928e5249b4e018b4af42d06a5eaaf86f437d93a5/src/Exchange.WebServices.NETCore/Core/EwsHttpWebRequest.cs#L129-L136

To then capture the cancellation in our client application we would need a clause like:
```csharp
                catch (Exception ex) when
                    (ex is Microsoft.Exchange.WebServices.Data.ServiceRequestException requestException &&
                     requestException.InnerException != null &&
                     string.Equals(
                         requestException.InnerException.Message,
                         "The operation was canceled.",
                         StringComparison.OrdinalIgnoreCase
                     ))
                {
                    throw new OperationCanceledException();
                }
```

To align this project more with the current way of doing things in dotnet, I've decided to forward the OperationCanceledException back to the caller so, the simpler form of capturing works:
```csharp
        try
        {
            _ = await Folder.Bind(service, WellKnownFolderName.Inbox, source.Token);
        }
        catch (OperationCanceledException)
        {
            // Captured!
        }
```

Sadly this is a breaking change, but the impact should be somewhat manageable.