### PR TITLE
Update HangingServiceRequestBase.cs deadlock issue

### DIFF
--- a/src/Exchange.WebServices.NETCore/Core/Requests/HangingServiceRequestBase.cs
+++ b/src/Exchange.WebServices.NETCore/Core/Requests/HangingServiceRequestBase.cs
@@ -301,13 +301,13 @@ internal abstract class HangingServiceRequestBase : ServiceRequestBase
     /// </summary>
     /// <param name="reason">The reason.</param>
     /// <param name="exception">The exception.</param>
-    internal void Disconnect(HangingRequestDisconnectReason reason, Exception? exception)
+    internal async void Disconnect(HangingRequestDisconnectReason reason, Exception? exception)
     {
         if (IsConnected)
         {
             _tokenSource.Cancel();
             // We do not care about exceptions here, as the ParseResponse handler provides a catch-all handler
-            _readTask.GetAwaiter().GetResult();
+            await _readTask;
 
             _response.Close();
             InternalOnDisconnect(reason, exception);


### PR DESCRIPTION
Hi, i have a deadlock issue with this piece of code 
It is called on subscription timeout and locks my app
So if we change GetAwaiter().GetResult(); to the async await it fixes the issue for me