### PR TITLE
fix autodiscover bug when using default credentials

### DIFF
--- a/src/Exchange.WebServices.NETCore/Core/ExchangeServiceBase.cs
+++ b/src/Exchange.WebServices.NETCore/Core/ExchangeServiceBase.cs
@@ -416,7 +416,7 @@ public abstract class ExchangeServiceBase : IDisposable
         : this(requestedServerVersion)
     {
         UseDefaultCredentials = service.UseDefaultCredentials;
-        Credentials = service.Credentials;
+        _credentials = service.Credentials;
         _traceEnabled = service._traceEnabled;
         _traceListener = service._traceListener;
         TraceFlags = service.TraceFlags;


### PR DESCRIPTION
I compared to ExchangeServiceBase.cs from [OfficeDev](https://github.com/OfficeDev/ews-managed-api/blob/master/Core/ExchangeServiceBase.cs, specifically line 539, where the credentials are assigned to a private variable rather than the Credentials property, which always sets UseDefaultCredentials to false.

